### PR TITLE
Add a failure threshold argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ The worker ID to monitor (usually the IP address of the connect worker). If none
 
 **Note**: It is highly recommended to run an instance of the healthcheck for each worker if you're planning to restart containers based on the health.
 
+#### Considered Containers
+A comma-separated list of which type of kafka connect container to be considered in the healthcheck calculation.
+
+| Usage                 | Value                                       |
+|-----------------------|---------------------------------------------|
+| Environment Variable  | `HEALTHCHECK_CONSIDERED_CONTAINERS`         |
+| Command-Line Argument | `--considered-containers`                   |
+| Default Value         | `CONNECTOR,TASK`                            |
+| Valid Values          | `CONNECTOR`, `TASK`                         |
+
 #### Unhealthy States
 A comma-separated list of connector and tasks states to be marked as unhealthy.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A simple healthcheck wrapper to monitor Kafka Connect.
     <img src="https://i.imgur.com/veSZDFf.png"/>
 </p>
 
-Kafka Connect Healthcheck is a server that wraps the Kafka Connect API and provides a singular API endpoint to determine the health of a Kafka Connect instance. This can be used to alert or take action on unhealthy connectors and tasks. 
+Kafka Connect Healthcheck is a server that wraps the Kafka Connect API and provides a singular API endpoint to determine the health of a Kafka Connect instance. This can be used to alert or take action on unhealthy connectors and tasks.
 
 This can be used in numerous ways. It can sit as a standalone service for monitoring purposes, it can be used as a sidecar container to mark Kafka Connect workers as unhealthy in Kubernetes, or it can be used to provide logs of when connectors/tasks failed and reasons for their failures.
 
@@ -38,7 +38,7 @@ kafka-connect-healthcheck
 The server will now be running on [localhost:18083][localhost].
 
 ### Docker
-The `kafka-connect-healthcheck` image can be found on Docker Hub. 
+The `kafka-connect-healthcheck` image can be found on Docker Hub.
 
 You can pull down the latest image by running:
 
@@ -55,7 +55,7 @@ docker run --rm -it -p 18083:18083 devshawn/kafka-connect-healthcheck
 The server will now be running on [localhost:18083][localhost].
 
 ## Configuration
-Kafka Connect Healthcheck can be configured via command-line arguments or by environment variables. 
+Kafka Connect Healthcheck can be configured via command-line arguments or by environment variables.
 
 #### Port
 The port for the `kafka-connect-healthcheck` API.
@@ -87,7 +87,7 @@ The worker ID to monitor (usually the IP address of the connect worker). If none
 **Note**: It is highly recommended to run an instance of the healthcheck for each worker if you're planning to restart containers based on the health.
 
 #### Unhealthy States
-A comma-separated list of connector and tasks states to be marked as unhealthy. 
+A comma-separated list of connector and tasks states to be marked as unhealthy.
 
 | Usage                 | Value                                       |
 |-----------------------|---------------------------------------------|
@@ -96,7 +96,19 @@ A comma-separated list of connector and tasks states to be marked as unhealthy.
 | Default Value         | `FAILED`                                    |
 | Valid Values          | `FAILED`, `PAUSED`, `UNASSIGNED`, `RUNNING` |
 
-**Note**: It's recommended to keep this defaulted to `FAILED`, but paused connectors or tasks can be marked as unhealthy by passing `FAILED,PAUSED`. 
+**Note**: It's recommended to keep this defaulted to `FAILED`, but paused connectors or tasks can be marked as unhealthy by passing `FAILED,PAUSED`.
+
+#### Percentage Failed
+A number between 1 and 100. If set, this is the percentage of connectors that must fail for the healthcheck to fail.
+
+| Usage                 | Value                                       |
+|-----------------------|---------------------------------------------|
+| Environment Variable  | `HEALTHCHECK_PERCENTAGE_FAILED`             |
+| Command-Line Argument | `--percentage-failed`                       |
+| Default Value         | `0`                                         |
+| Valid Values          | 1 to 100                                    |
+
+By default, **any** failures will cause the healthcheck to fail.
 
 #### Log Level
 The level of logs to be shown by the application.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ A comma-separated list of connector and tasks states to be marked as unhealthy.
 
 **Note**: It's recommended to keep this defaulted to `FAILED`, but paused connectors or tasks can be marked as unhealthy by passing `FAILED,PAUSED`.
 
-#### Percentage Failed
+#### Failure Threshold Percentage
 A number between 1 and 100. If set, this is the percentage of connectors that must fail for the healthcheck to fail.
 
 | Usage                 | Value                                       |

--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ A number between 1 and 100. If set, this is the percentage of connectors that mu
 
 | Usage                 | Value                                       |
 |-----------------------|---------------------------------------------|
-| Environment Variable  | `HEALTHCHECK_PERCENTAGE_FAILED`             |
-| Command-Line Argument | `--percentage-failed`                       |
+| Environment Variable  | `HEALTHCHECK_FAILURE_THRESHOLD_PERCENTAGE`  |
+| Command-Line Argument | `--failure-threshold-percentage`            |
 | Default Value         | `0`                                         |
 | Valid Values          | 1 to 100                                    |
 

--- a/kafka_connect_healthcheck/health.py
+++ b/kafka_connect_healthcheck/health.py
@@ -55,10 +55,14 @@ class Health:
             if container_count > 0:
                 health_result["failure_rate"] = failure_count/container_count
             else:
-                health_result["failure_rate"] = 0
+                health_result["failure_rate"] = 0.0
 
             health_result["failure_threshold"] = self.failure_threshold
             health_result["healthy"] = health_result["failure_rate"] <= health_result["failure_threshold"]
+
+            # broker errors override any failure calculation
+            if any([f for f in health_result["failures"] if f["type"] == "broker"]):
+                health_result["healthy"] = False
 
         except Exception as ex:
             logging.error("Error while attempting to calculate health result. Assuming unhealthy. Error: {}".format(ex))

--- a/kafka_connect_healthcheck/health.py
+++ b/kafka_connect_healthcheck/health.py
@@ -22,11 +22,11 @@ from kafka_connect_healthcheck import helpers
 
 class Health:
 
-    def __init__(self, connect_url, worker_id, unhealthy_states, auth, percentage_failed):
+    def __init__(self, connect_url, worker_id, unhealthy_states, auth, failure_threshold_percentage):
         self.connect_url = connect_url
         self.worker_id = worker_id
         self.unhealthy_states = [x.upper().strip() for x in unhealthy_states]
-        self.failed_threshold = percentage_failed * .01
+        self.failure_threshold = failure_threshold_percentage * .01
         self.kwargs = {}
         if auth and ":" in auth:
             self.kwargs["auth"] = tuple(auth.split(":"))
@@ -40,10 +40,12 @@ class Health:
             self.handle_healthcheck(connector_statuses, health_result)
 
             connector_count = len(connector_names)
-            failure_count = len(health_result["failures"])
+            failure_count = len([f for f in health_result["failures"] if f["type"] == "connector"])
+            health_result["failure_rate"] = failure_count/connector_count
+            health_result["failure_threshold"] = self.failure_threshold
 
             if failure_count > 0:
-                health_result["healthy"] = connector_count/failure_count <= self.failed_threshold
+                health_result["healthy"] = health_result["failure_rate"] <= health_result["failure_threshold"]
             else:
                 health_result["healthy"] = True
 

--- a/kafka_connect_healthcheck/main.py
+++ b/kafka_connect_healthcheck/main.py
@@ -37,7 +37,7 @@ def main():
 
     server_class = HTTPServer
     health_object = health.Health(args.connect_url, args.connect_worker_id, args.unhealthy_states.split(","),
-                                  args.basic_auth)
+                                  args.basic_auth, args.percentage_failed)
     handler = partial(RequestHandler, health_object)
     httpd = server_class(("0.0.0.0", args.healthcheck_port), handler)
     logging.info("Healthcheck server started at: http://localhost:{}".format(args.healthcheck_port))

--- a/kafka_connect_healthcheck/main.py
+++ b/kafka_connect_healthcheck/main.py
@@ -37,7 +37,7 @@ def main():
 
     server_class = HTTPServer
     health_object = health.Health(args.connect_url, args.connect_worker_id, args.unhealthy_states.split(","),
-                                  args.basic_auth, args.failure_threshold_percentage)
+                                  args.basic_auth, args.failure_threshold_percentage, args.considered_containers.split(","))
     handler = partial(RequestHandler, health_object)
     httpd = server_class(("0.0.0.0", args.healthcheck_port), handler)
     logging.info("Healthcheck server started at: http://localhost:{}".format(args.healthcheck_port))

--- a/kafka_connect_healthcheck/main.py
+++ b/kafka_connect_healthcheck/main.py
@@ -37,7 +37,7 @@ def main():
 
     server_class = HTTPServer
     health_object = health.Health(args.connect_url, args.connect_worker_id, args.unhealthy_states.split(","),
-                                  args.basic_auth, args.percentage_failed)
+                                  args.basic_auth, args.failure_threshold_percentage)
     handler = partial(RequestHandler, health_object)
     httpd = server_class(("0.0.0.0", args.healthcheck_port), handler)
     logging.info("Healthcheck server started at: http://localhost:{}".format(args.healthcheck_port))

--- a/kafka_connect_healthcheck/parser.py
+++ b/kafka_connect_healthcheck/parser.py
@@ -52,6 +52,14 @@ def get_parser():
                         help="A comma separated lists of connector and task states to be marked as unhealthy. Default: FAILED."
                         )
 
+    parser.add_argument("--percentage-failed",
+                        default=os.environ.get("HEALTHCHECK_PERCENTAGE_FAILED", 0),
+                        dest="percentage_failed",
+                        type=int,
+                        nargs="?",
+                        help="A number between 1 and 100. If set, this is the percentage of connectors that must fail for the healthcheck to fail."
+                        )
+
     parser.add_argument("--basic-auth",
                         default=os.environ.get("HEALTHCHECK_BASIC_AUTH", ""),
                         dest="basic_auth",

--- a/kafka_connect_healthcheck/parser.py
+++ b/kafka_connect_healthcheck/parser.py
@@ -52,9 +52,9 @@ def get_parser():
                         help="A comma separated lists of connector and task states to be marked as unhealthy. Default: FAILED."
                         )
 
-    parser.add_argument("--percentage-failed",
-                        default=os.environ.get("HEALTHCHECK_PERCENTAGE_FAILED", 0),
-                        dest="percentage_failed",
+    parser.add_argument("--failure-threshold-percentage",
+                        default=os.environ.get("HEALTHCHECK_FAILURE_THRESHOLD_PERCENTAGE", 0),
+                        dest="failure_threshold_percentage",
                         type=int,
                         nargs="?",
                         help="A number between 1 and 100. If set, this is the percentage of connectors that must fail for the healthcheck to fail."

--- a/kafka_connect_healthcheck/parser.py
+++ b/kafka_connect_healthcheck/parser.py
@@ -52,6 +52,13 @@ def get_parser():
                         help="A comma separated lists of connector and task states to be marked as unhealthy. Default: FAILED."
                         )
 
+    parser.add_argument("--considered-containers",
+                        default=os.environ.get("HEALTHCHECK_CONSIDERED_CONTAINERS", "CONNECTOR,TASK").upper(),
+                        dest="considered_containers",
+                        nargs="?",
+                        help="A comma separated lists of container types to consider for failure calculations. Default: CONNECTOR,TASK."
+                        )
+
     parser.add_argument("--failure-threshold-percentage",
                         default=os.environ.get("HEALTHCHECK_FAILURE_THRESHOLD_PERCENTAGE", 0),
                         dest="failure_threshold_percentage",

--- a/tests/data/expected/1-healthy.json
+++ b/tests/data/expected/1-healthy.json
@@ -3,5 +3,7 @@
     "failure_states": [
         "FAILED"
     ],
+    "failure_rate": 0.0,
+    "failure_threshold": 0.0,
     "healthy": true
 }

--- a/tests/data/expected/10-unhealthy-multiple-connectors.json
+++ b/tests/data/expected/10-unhealthy-multiple-connectors.json
@@ -26,5 +26,7 @@
     "failure_states": [
         "FAILED"
     ],
+    "failure_rate": 0.3,
+    "failure_threshold": 0.0,
     "healthy": false
 }

--- a/tests/data/expected/11-healthy-no-connectors.json
+++ b/tests/data/expected/11-healthy-no-connectors.json
@@ -3,5 +3,7 @@
     "failure_states": [
         "FAILED"
     ],
+    "failure_rate": 0.0,
+    "failure_threshold": 0.0,
     "healthy": true
 }

--- a/tests/data/expected/12-unhealthy-task-with-trace.json
+++ b/tests/data/expected/12-unhealthy-task-with-trace.json
@@ -12,5 +12,7 @@
     "failure_states": [
         "FAILED"
     ],
+    "failure_rate": 0.3333333333333333,
+    "failure_threshold": 0.0,
     "healthy": false
 }

--- a/tests/data/expected/13-unhealthy-broker-connection.json
+++ b/tests/data/expected/13-unhealthy-broker-connection.json
@@ -8,5 +8,7 @@
     "failure_states": [
         "FAILED"
     ],
+    "failure_rate": 0.0,
+    "failure_threshold": 0.0,
     "healthy": false
 }

--- a/tests/data/expected/14-basic-auth.json
+++ b/tests/data/expected/14-basic-auth.json
@@ -3,5 +3,7 @@
     "failure_states": [
         "FAILED"
     ],
+    "failure_rate": 0.0,
+    "failure_threshold": 0.0,
     "healthy": true
 }

--- a/tests/data/expected/2-unhealthy.json
+++ b/tests/data/expected/2-unhealthy.json
@@ -18,5 +18,7 @@
     "failure_states": [
         "FAILED"
     ],
+    "failure_rate": 1.0,
+    "failure_threshold": 0.0,
     "healthy": false
 }

--- a/tests/data/expected/4-healthy-worker-id-correct.json
+++ b/tests/data/expected/4-healthy-worker-id-correct.json
@@ -3,5 +3,7 @@
     "failure_states": [
         "FAILED"
     ],
+    "failure_rate": 0.0,
+    "failure_threshold": 0.0,
     "healthy": true
 }

--- a/tests/data/expected/5-healthy-worker-id-unused.json
+++ b/tests/data/expected/5-healthy-worker-id-unused.json
@@ -3,5 +3,7 @@
     "failure_states": [
         "FAILED"
     ],
+    "failure_rate": 0.0,
+    "failure_threshold": 0.0,
     "healthy": true
 }

--- a/tests/data/expected/6-healthy-worker-id-with-other-workers-failing.json
+++ b/tests/data/expected/6-healthy-worker-id-with-other-workers-failing.json
@@ -3,5 +3,7 @@
     "failure_states": [
         "FAILED"
     ],
+    "failure_rate": 0.0,
+    "failure_threshold": 0.0,
     "healthy": true
 }

--- a/tests/data/expected/7-unhealthy-worker-id-with-other-workers-healthy.json
+++ b/tests/data/expected/7-unhealthy-worker-id-with-other-workers-healthy.json
@@ -12,5 +12,7 @@
     "failure_states": [
         "FAILED"
     ],
+    "failure_rate": 0.5,
+    "failure_threshold": 0.0,
     "healthy": false
 }

--- a/tests/data/expected/8-healthy-multiple-tasks.json
+++ b/tests/data/expected/8-healthy-multiple-tasks.json
@@ -3,5 +3,7 @@
     "failure_states": [
         "FAILED"
     ],
+    "failure_rate": 0.0,
+    "failure_threshold": 0.0,
     "healthy": true
 }

--- a/tests/data/expected/9-healthy-multiple-connectors.json
+++ b/tests/data/expected/9-healthy-multiple-connectors.json
@@ -3,5 +3,7 @@
     "failure_states": [
         "FAILED"
     ],
+    "failure_rate": 0.0,
+    "failure_threshold": 0.0,
     "healthy": true
 }


### PR DESCRIPTION
When wanting to use this healthcheck as the "liveness" probe of kafka-connect in kubernetes, theres an issue where a single failed task could cause the restart of an entire pod. This sets a percentage value for connector failures, which are reflective of any failure in the tasks below them. In our case this means we can start rebooting a pod to fix say database outages when more than half of all connectors on it have failed.